### PR TITLE
Fix naming of array items to conform to acro spec

### DIFF
--- a/src/zod-to-avro.ts
+++ b/src/zod-to-avro.ts
@@ -85,7 +85,7 @@ export const zodToAvro = (
       return {
         type: "array",
         items: zodToAvro(
-          `${name}-value`,
+          `${name}_value`,
           zodArray.value._def.type,
           options,
           cache


### PR DESCRIPTION
Following the spec (see below) the name properties in avro schema are not allowed to include dashes, only underscores.
This fixes that, following my issue from last week ;).

https://avro.apache.org/docs/1.11.1/specification/#names